### PR TITLE
API-417: extract setup of entities

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -4,7 +4,7 @@ import org.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateAction
 
 String launchUnitTests = "yes"
 String launchIntegrationTests = "yes"
-String[] pimVersions = ["1.7", "master"]
+String[] pimVersions = ["1.7", "2.0"]
 String[] supportedPhpVersions = ["5.6", "7.0", "7.1"]
 def clientConfig = [
     "php-http/guzzle6-adapter": ["phpVersion": supportedPhpVersions, "psrImplem": ["guzzlehttp/psr7"]],
@@ -59,7 +59,7 @@ try {
                     case "1.7":
                         checkouts["pim_community_dev_${currentPimVersion}"] = {buildPim(currentPimVersion, "5.6")}
                         break
-                    case "master":
+                    case "2.0":
                         checkouts["pim_community_dev_${currentPimVersion}"] = {buildPim(currentPimVersion, "7.1")}
                         break
                     default:
@@ -171,7 +171,7 @@ void buildPim(String pimVersion, String phpVersion) {
                 sh "composer --ansi require \"akeneo/catalogs\":\"dev-master\" --optimize-autoloader --no-interaction --no-progress --prefer-dist"
                 sh "cp app/config/parameters.yml.dist app/config/parameters.yml"
                 sh "sed -i \"s#database_host: .*#database_host: 127.0.0.1#g\" app/config/parameters.yml"
-                if ("master" == pimVersion) {
+                if ("2.0" == pimVersion) {
                     sh "sed -i \"s#index_hosts: .*#index_hosts: 'elastic:changeme@127.0.0.1:9200'#g\" app/config/parameters.yml"
                 }
                 sh "sed -i \"s#installer_data: .*#installer_data: '%kernel.root_dir%/../vendor/akeneo/catalogs/${pimVersion}/community/api/fixtures'#\" app/config/pim_parameters.yml"
@@ -209,7 +209,7 @@ void buildClient(String phpVersion, String client, String psrImplem) {
 
             String gcrImageName = getApiClientGCRImageName(phpVersion, client, psrImplem)
             saveDockerData(gcrImageName)
-            
+
             // Add image to array for cleanup
             gcrImages += "${gcrImageName}"
         }
@@ -279,7 +279,7 @@ void runIntegrationTest(String phpVersion, String client, String psrImplem, Stri
         case "1.7":
             runPim17IntegrationTest(phpVersion, client, psrImplem)
             break
-        case "master":
+        case "2.0":
             runPim20IntegrationTest(phpVersion, client, psrImplem)
             break
         default:
@@ -362,7 +362,7 @@ def runPim17IntegrationTest(String phpVersion, String client, String psrImplem) 
  * @param psrImplem  Name of the PSR 7 implementation package to run the test with
  */
 def runPim20IntegrationTest(String phpVersion, String client, String psrImplem) {
-    String pimVersion       = "master"
+    String pimVersion       = "2.0"
     String phpApiImageName  = getApiClientGCRImageName(phpVersion, client, psrImplem)
     String pimImageName     = getPimGCRImageName(pimVersion)
 
@@ -404,10 +404,10 @@ def runPim20IntegrationTest(String phpVersion, String client, String psrImplem) 
 }
 
 /**
- * This function allow you to run Google Cloud commands 
- * 
+ * This function allow you to run Google Cloud commands
+ *
  * @param body              Groovy script to execute inside Jenkins node
- * 
+ *
  * Kubernetes Template :
  * (Default location is set to "/home/jenkins")
  *  - (Run)  docker         : Run Google Cloud commands inside
@@ -451,10 +451,10 @@ def withBuildNode(String phpVersion, body) {
 }
 
 /**
- * This function allow you to run Google Cloud commands 
- * 
+ * This function allow you to run Google Cloud commands
+ *
  * @param body              Groovy script to execute inside "docker" container
- * 
+ *
  * Kubernetes Template :
  *  - (Run)  docker         : Run Google Cloud commands inside
  */
@@ -483,12 +483,12 @@ def withDockerGcloud(body) {
 }
 
 /**
- * This function allow you to run php commands with php-api-client sources 
- * 
+ * This function allow you to run php commands with php-api-client sources
+ *
  * @param phpApiImageName   Full GCR image name to pull, containing php-api-client data
  * @param phpVersion        PHP version to run the test with
  * @param body              Groovy script to execute inside "php" container
- * 
+ *
  * Kubernetes Template :
  *  - (Init) php-api-client : Copy php-api-client sources to /home/jenkins/php-api-client
  *  - (Run)  php            : Run PHP commands inside
@@ -530,15 +530,15 @@ def withPhpApi(String phpApiImageName, String phpVersion, body) {
 }
 
 /**
- * This function allow you to run a list of messages on parallel pods. 
+ * This function allow you to run a list of messages on parallel pods.
  * Each message will create a kubernetes pod (based on template) and run its commands sequentially.
- * 
+ *
  * @param phpApiImageName   Full GCR image name to pull, containing php-api-client data
  * @param pimImageName      Full GCR image name to pull, containing pim data
  * @param pimVersion        PIM version to run the test with
  * @param phpVersion        PHP version to run the test with
  * @param body              JSON Array containing the list of messages to execute in parallel
- * 
+ *
  * Kubernetes Template :
  *  - (Init) php-api-client : Copy php-api-client sources to /home/jenkins/php-api-client (Used for K8s PIM's template)
  *  - (Run)  gcloud         : Used to manage pubsub queues and to create PIM's Kubernetes pods (Based on template)
@@ -555,7 +555,7 @@ def queue(String phpApiImageName, String pimImageName, String pimVersion, String
         case "1.7":
             k8s_template = "pim_17_ce.yaml"
             break
-        case "master":
+        case "2.0":
             k8s_template = "pim_20_ce.yaml"
             break
         default:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 String launchUnitTests = "yes"
 String launchIntegrationTests = "yes"
-def pimVersions = ["1.7", "master"]
+def pimVersions = ["1.7", "2.0"]
 def supportedPhpVersions = ["5.6", "7.0", "7.1"]
 
 def clientConfig = [
@@ -62,7 +62,7 @@ stage("Checkout") {
         for (pimVersion in pimVersions) {
             String currentPimVersion = pimVersion
 
-            if ("master" == currentPimVersion) {
+            if ("2.0" == currentPimVersion) {
                 checkouts["pim_community_dev_${currentPimVersion}"] = {runCheckoutPim18(currentPimVersion)}
             }
 
@@ -305,7 +305,7 @@ void runIntegrationTest(String phpVersion, String client, String psrImplem, Stri
             dir('pim') {
                 unstash "pim_community_dev_${pimVersion}"
 
-                if ("master" == pimVersion) {
+                if ("2.0" == pimVersion) {
                     sh "docker pull akeneo/fpm:php-7.1 || true"
 
                     sh "docker run --name mysql -e MYSQL_ROOT_PASSWORD=root -e MYSQL_USER=akeneo_pim -e MYSQL_PASSWORD=akeneo_pim -e MYSQL_DATABASE=akeneo_pim --tmpfs=/var/lib/mysql/:rw,noexec,nosuid,size=400m --tmpfs=/tmp/:rw,noexec,nosuid,size=200m -d mysql:5.7"
@@ -331,7 +331,7 @@ void runIntegrationTest(String phpVersion, String client, String psrImplem, Stri
             unstash "php-api-client_${client}_${psrImplem}_php-${phpVersion}".replaceAll("/", "_")
             sh "mkdir -p build/logs/"
 
-            if ("master" == pimVersion) {
+            if ("2.0" == pimVersion) {
                 docker.image("akeneo/php:${phpVersion}").inside("--link akeneo-pim:akeneo-pim --link httpd:httpd -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker -w /home/docker/client --privileged") {
                     sh "sed -i \"s#baseUri: .*#baseUri: 'http://httpd'#g\" etc/parameters.yml"
                     sh "sed -i \"s#bin_path: .*#bin_path: bin#g\" etc/parameters.yml"

--- a/src/AkeneoPimClientBuilder.php
+++ b/src/AkeneoPimClientBuilder.php
@@ -140,23 +140,7 @@ class AkeneoPimClientBuilder
      */
     protected function buildAuthenticatedClient(Authentication $authentication)
     {
-        $uriGenerator = new UriGenerator($this->baseUri);
-
-        $httpClient = new HttpClient($this->getHttpClient(), $this->getRequestFactory());
-        $authenticationApi = new AuthenticationApi($httpClient, $uriGenerator);
-        $authenticatedHttpClient = new AuthenticatedHttpClient($httpClient, $authenticationApi, $authentication);
-
-        $multipartStreamBuilderFactory = new MultipartStreamBuilderFactory($this->getStreamFactory());
-        $upsertListResponseFactory = new UpsertResourceListResponseFactory();
-        $resourceClient = new ResourceClient(
-            $authenticatedHttpClient,
-            $uriGenerator,
-            $multipartStreamBuilderFactory,
-            $upsertListResponseFactory
-        );
-
-        $pageFactory = new PageFactory($authenticatedHttpClient);
-        $cursorFactory = new ResourceCursorFactory();
+        list($resourceClient, $pageFactory, $cursorFactory) = $this->setUp($authentication);
 
         $client = new AkeneoPimClient(
             $authentication,
@@ -213,5 +197,33 @@ class AkeneoPimClientBuilder
         }
 
         return $this->streamFactory;
+    }
+
+    /**
+     * @param Authentication $authentication
+     *
+     * @return array
+     */
+    protected function setUp(Authentication $authentication): array
+    {
+        $uriGenerator = new UriGenerator($this->baseUri);
+
+        $httpClient = new HttpClient($this->getHttpClient(), $this->getRequestFactory());
+        $authenticationApi = new AuthenticationApi($httpClient, $uriGenerator);
+        $authenticatedHttpClient = new AuthenticatedHttpClient($httpClient, $authenticationApi, $authentication);
+
+        $multipartStreamBuilderFactory = new MultipartStreamBuilderFactory($this->getStreamFactory());
+        $upsertListResponseFactory = new UpsertResourceListResponseFactory();
+        $resourceClient = new ResourceClient(
+            $authenticatedHttpClient,
+            $uriGenerator,
+            $multipartStreamBuilderFactory,
+            $upsertListResponseFactory
+        );
+
+        $pageFactory = new PageFactory($authenticatedHttpClient);
+        $cursorFactory = new ResourceCursorFactory();
+
+        return [$resourceClient, $pageFactory, $cursorFactory];
     }
 }

--- a/src/AkeneoPimClientBuilder.php
+++ b/src/AkeneoPimClientBuilder.php
@@ -204,7 +204,7 @@ class AkeneoPimClientBuilder
      *
      * @return array
      */
-    protected function setUp(Authentication $authentication): array
+    protected function setUp(Authentication $authentication)
     {
         $uriGenerator = new UriGenerator($this->baseUri);
 

--- a/src/AkeneoPimClientBuilder.php
+++ b/src/AkeneoPimClientBuilder.php
@@ -64,6 +64,8 @@ class AkeneoPimClientBuilder
     }
 
     /**
+     * Allows to directly set a client instead of using HttpClientDiscovery::find()
+     *
      * @param Client $httpClient
      *
      * @return AkeneoPimClientBuilder
@@ -76,6 +78,8 @@ class AkeneoPimClientBuilder
     }
 
     /**
+     * Allows to directly set a request factory instead of using MessageFactoryDiscovery::find()
+     *
      * @param RequestFactory $requestFactory
      *
      * @return AkeneoPimClientBuilder
@@ -88,6 +92,8 @@ class AkeneoPimClientBuilder
     }
 
     /**
+     * Allows to directly set a stream factory instead of using StreamFactoryDiscovery::find()
+     *
      * @param StreamFactory $streamFactory
      *
      * @return AkeneoPimClientBuilder
@@ -164,42 +170,6 @@ class AkeneoPimClientBuilder
     }
 
     /**
-     * @return Client
-     */
-    protected function getHttpClient()
-    {
-        if (null === $this->httpClient) {
-            $this->httpClient = HttpClientDiscovery::find();
-        }
-
-        return $this->httpClient;
-    }
-
-    /**
-     * @return RequestFactory
-     */
-    protected function getRequestFactory()
-    {
-        if (null === $this->requestFactory) {
-            $this->requestFactory = MessageFactoryDiscovery::find();
-        }
-
-        return $this->requestFactory;
-    }
-
-    /**
-     * @return StreamFactory
-     */
-    public function getStreamFactory()
-    {
-        if (null === $this->streamFactory) {
-            $this->streamFactory = StreamFactoryDiscovery::find();
-        }
-
-        return $this->streamFactory;
-    }
-
-    /**
      * @param Authentication $authentication
      *
      * @return array
@@ -226,4 +196,41 @@ class AkeneoPimClientBuilder
 
         return [$resourceClient, $pageFactory, $cursorFactory];
     }
+
+    /**
+     * @return Client
+     */
+    private function getHttpClient()
+    {
+        if (null === $this->httpClient) {
+            $this->httpClient = HttpClientDiscovery::find();
+        }
+
+        return $this->httpClient;
+    }
+
+    /**
+     * @return RequestFactory
+     */
+    private function getRequestFactory()
+    {
+        if (null === $this->requestFactory) {
+            $this->requestFactory = MessageFactoryDiscovery::find();
+        }
+
+        return $this->requestFactory;
+    }
+
+    /**
+     * @return StreamFactory
+     */
+    private function getStreamFactory()
+    {
+        if (null === $this->streamFactory) {
+            $this->streamFactory = StreamFactoryDiscovery::find();
+        }
+
+        return $this->streamFactory;
+    }
+
 }

--- a/src/AkeneoPimClientBuilder.php
+++ b/src/AkeneoPimClientBuilder.php
@@ -232,5 +232,4 @@ class AkeneoPimClientBuilder
 
         return $this->streamFactory;
     }
-
 }

--- a/tests/Common/Api/ApiTestCase.php
+++ b/tests/Common/Api/ApiTestCase.php
@@ -20,6 +20,14 @@ use Symfony\Component\Yaml\Yaml;
 abstract class ApiTestCase extends \PHPUnit_Framework_TestCase
 {
     /**
+     * @return StreamFactory
+     */
+    public function getStreamFactory()
+    {
+        return StreamFactoryDiscovery::find();
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function setUp()
@@ -63,7 +71,7 @@ abstract class ApiTestCase extends \PHPUnit_Framework_TestCase
      */
     protected function getConfiguration()
     {
-        $configFile = realpath(dirname(__FILE__)).'/../../../etc/parameters.yml';
+        $configFile = $this->getConfigurationFile();
         if (!is_file($configFile)) {
             throw new \RuntimeException('The configuration file parameters.yml is missing');
         }
@@ -74,11 +82,11 @@ abstract class ApiTestCase extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return StreamFactory
+     * @return string
      */
-    public function getStreamFactory()
+    protected function getConfigurationFile()
     {
-        return StreamFactoryDiscovery::find();
+        return realpath(dirname(__FILE__)).'/../../../etc/parameters.yml';
     }
 
     /**

--- a/tests/Common/Api/ApiTestCase.php
+++ b/tests/Common/Api/ApiTestCase.php
@@ -53,7 +53,11 @@ abstract class ApiTestCase extends \PHPUnit_Framework_TestCase
             $generator = new DockerCredentialGenerator($config['pim']['docker_name']);
         }
 
-        $credentials = $generator->generate($config['pim']['install_path'], $config['pim']['bin_path'], $config['pim']['version']);
+        $credentials = $generator->generate(
+            $config['pim']['install_path'],
+            $config['pim']['bin_path'],
+            $config['pim']['version']
+        );
         $clientBuilder = new AkeneoPimClientBuilder($config['api']['baseUri']);
 
         return $clientBuilder->buildAuthenticatedByPassword(
@@ -90,8 +94,10 @@ abstract class ApiTestCase extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Assert that all the expected data of a content of a resource are the same in an actual one.
-     * An associative array can contain more elements than expected, but an numeric key array must be strictly identical.
+     * Assert that all the expected data of a content of a resource are the same
+     * in an actual one.
+     * An associative array can contain more elements than expected, but an
+     * numeric key array must be strictly identical.
      *
      * @param array $expectedContent
      * @param array $actualContent


### PR DESCRIPTION
This PR extracts the setup of the client in the ClientBuilder, to allow a minimum override in the EE client => https://github.com/akeneo/api-php-client-ee/pull/2.

It also extracts some configuration of the ApiTestCase, to allow an easy setup of the tests in EE too.

Finally, the CI now build against Akeneo 2.0 and not the master branch.

This PR will need https://github.com/akeneo/catalogs/pull/65 and https://github.com/akeneo/pim-community-dev/pull/7119 to be merged first.