### PR TITLE
API-421: Add a "ValueSanitizer"

### DIFF
--- a/tests/Common/Api/ApiTestCase.php
+++ b/tests/Common/Api/ApiTestCase.php
@@ -27,29 +27,21 @@ abstract class ApiTestCase extends \PHPUnit_Framework_TestCase
     /**
      * {@inheritdoc}
      */
-    public function __construct($name = null, array $data = [], $dataName = '')
+    protected function setUp()
     {
-        parent::__construct($name, $data, $dataName);
-
         $this->configuration = $this->parseConfigurationFile();
         $this->consoleCommandLauncher = new ConsoleCommandLauncher($this->getConfiguration());
+
+        $installer = new DatabaseInstaller($this->getCommandLauncher());
+        $installer->install();
     }
 
     /**
      * @return StreamFactory
      */
-    public function getStreamFactory()
+    protected function getStreamFactory()
     {
         return StreamFactoryDiscovery::find();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function setUp()
-    {
-        $installer = new DatabaseInstaller($this->getCommandLauncher());
-        $installer->install();
     }
 
     /**
@@ -126,7 +118,7 @@ abstract class ApiTestCase extends \PHPUnit_Framework_TestCase
     /**
      * @return string
      */
-    private function getConfigurationFile()
+    protected function getConfigurationFile()
     {
         return realpath(dirname(__FILE__)).'/../../../etc/parameters.yml';
     }

--- a/tests/Common/Api/Product/AbstractProductApiTestCase.php
+++ b/tests/Common/Api/Product/AbstractProductApiTestCase.php
@@ -3,8 +3,7 @@
 namespace Akeneo\Pim\tests\Common\Api\Product;
 
 use Akeneo\Pim\tests\Common\Api\ApiTestCase;
-use Akeneo\Pim\tests\DateSanitizer;
-use Akeneo\Pim\tests\MediaSanitizer;
+use Akeneo\Pim\tests\ValuesSanitizer;
 
 /**
  * @author    Laurent Petard <laurent.petard@akeneo.com>
@@ -22,15 +21,6 @@ abstract class AbstractProductApiTestCase extends ApiTestCase
      */
     protected function sanitizeProductData(array $productData)
     {
-        foreach ($productData as $key => $value) {
-            if (is_array($value)) {
-                $productData[$key] = $this->sanitizeProductData($value);
-            } else {
-                $productData[$key] = DateSanitizer::sanitize($productData[$key]);
-                $productData[$key] = MediaSanitizer::sanitize($productData[$key]);
-            }
-        }
-
-        return $productData;
+        return ValuesSanitizer::sanitize($productData);
     }
 }

--- a/tests/ValuesSanitizer.php
+++ b/tests/ValuesSanitizer.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Akeneo\Pim\tests;
+
+/**
+ * Sanitizes a collection of normalized values.
+ *
+ * @author    Damien Carcel <damien.carcel@gmail.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ValuesSanitizer
+{
+    /**
+     * @param mixed $values
+     *
+     * @return mixed
+     */
+    public static function sanitize($values)
+    {
+        foreach ($values as $key => $value) {
+            if (is_array($value)) {
+                $values[$key] = static::sanitize($value);
+            } else {
+                $values[$key] = DateSanitizer::sanitize($values[$key]);
+                $values[$key] = MediaSanitizer::sanitize($values[$key]);
+            }
+        }
+
+        return $values;
+    }
+}


### PR DESCRIPTION
This PR extract the product sanitation into a dedicated class, so it can be used for published products and product draft in the EE client without code duplication.

It also removes the constructor from the `ApiTestCase`, putting the initialization of some variables into the `setup` method.

~Needs https://github.com/akeneo/api-php-client/pull/89 to be merged first.~ Done