### PR TITLE
 Add a compose file template 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 bin
 vendor
 composer.lock
-/phpspec.yml
-.php_cs.cache
+docker-compose.yml
 etc/parameters.yml
+phpspec.yml
 phpunit.xml
+.php_cs.cache

--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -1,0 +1,26 @@
+version: '2'
+
+services:
+  client:
+    image: akeneo/php:7.1
+    environment:
+      COMPOSER_HOME: /home/docker/.composer
+      PHP_IDE_CONFIG: 'serverName=akeneo-client'
+      PHP_XDEBUG_ENABLED: 0
+      PHP_XDEBUG_IDE_KEY: XDEBUG_IDE_KEY
+      PHP_XDEBUG_REMOTE_HOST: xxx.xxx.xxx.xxx
+      XDEBUG_CONFIG: 'remote_host=xxx.xxx.xxx.xxx'
+    user: docker
+    volumes:
+      - ./:/home/docker/client
+      - ~/.composer:/home/docker/.composer
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /usr/bin/docker:/usr/bin/docker
+    working_dir: /home/docker/client
+    networks:
+      - client
+
+networks:
+  default:
+      external:
+        name: your-pim-network  # Replace with the Docker network your PIM is on


### PR DESCRIPTION
This will ease using Docker on a local machine, and allow to reproduce the same behavior than on the CI.

`.gitignore` was also alphabetically reordered, with folder first, and hidden files last.