### PR TITLE
 Refactorize parameters in tests 

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -202,9 +202,9 @@ void buildClient(String phpVersion, String client, String psrImplem) {
             container("php") {
                 sh "composer --ansi require ${client} ${psrImplem}"
                 sh "composer --ansi update --optimize-autoloader --no-interaction --no-progress --prefer-dist --no-suggest"
-                sh "cp etc/parameters.yml.dist etc/parameters.yml"
-                sh "sed -i \"s#baseUri: .*#baseUri: 'http://akeneo-pim'#g\" etc/parameters.yml"
-                sh "sed -i \"s#install_path: .*#install_path: '/home/jenkins/pim'#g\" etc/parameters.yml"
+                sh "cp tests/etc/parameters.yml.dist tests/etc/parameters.yml"
+                sh "sed -i \"s#base_uri: .*#base_uri: 'http://akeneo-pim'#g\" tests/etc/parameters.yml"
+                sh "sed -i \"s#install_path: .*#install_path: '/home/jenkins/pim'#g\" tests/etc/parameters.yml"
             }
 
             String gcrImageName = getApiClientGCRImageName(phpVersion, client, psrImplem)
@@ -324,7 +324,7 @@ def runPim17IntegrationTest(String phpVersion, String client, String psrImplem) 
                 // And clean kubernetes' docker prefix "docker://<container-id>" (Take care, pubsub uses Busybox's sed != GNU sed)
                 [container: "pubsub", script: '''sh -c "kubectl get pod \\${POD_NAME} -o jsonpath='{$.status.containerStatuses[?(@.name==\\"php\\")].containerID}' | sed 's#docker://##g' > /home/jenkins/php-container-id" '''],
                 // Set "php" container id to parameters.yml
-                [container: "php-api", script: '''sh -c 'sed -i "s#docker_name: .*#docker_name: $(cat /home/jenkins/php-container-id)#g" etc/parameters.yml' '''],
+                [container: "php-api", script: '''sh -c 'sed -i "s#docker_name: .*#docker_name: $(cat /home/jenkins/php-container-id)#g" tests/etc/parameters.yml' '''],
                 // Copy apache configuration for Kubernetes
                 [container: "php", script: "sudo cp /home/jenkins/php-api-client/.ci/akeneo.conf /etc/apache2/sites-available/000-default.conf"],
                 // Own pim folder to docker user/group (which is also the apache user)
@@ -380,10 +380,10 @@ def runPim20IntegrationTest(String phpVersion, String client, String psrImplem) 
                 // And clean kubernetes' docker prefix "docker://<container-id>" (Take care, pubsub uses Busybox's sed != GNU sed)
                 [container: "pubsub", script: '''sh -c "kubectl get pod \\${POD_NAME} -o jsonpath='{$.status.containerStatuses[?(@.name==\\"php\\")].containerID}' | sed 's#docker://##g' > /home/jenkins/php-container-id" '''],
                 // Set "php" container id to parameters.yml
-                [container: "php-api", script: '''sh -c 'sed -i "s#docker_name: .*#docker_name: $(cat /home/jenkins/php-container-id)#g" etc/parameters.yml' '''],
+                [container: "php-api", script: '''sh -c 'sed -i "s#docker_name: .*#docker_name: $(cat /home/jenkins/php-container-id)#g" tests/etc/parameters.yml' '''],
                 // Change php-api-client conf for Pim 2.x
-                [container: "php-api", script: '''sed -i 's#bin_path: .*#bin_path: bin#g' etc/parameters.yml'''],
-                [container: "php-api", script: '''sed -i 's#version: .*#version: #g' etc/parameters.yml'''],
+                [container: "php-api", script: '''sed -i 's#bin_path: .*#bin_path: bin#g' tests/etc/parameters.yml'''],
+                [container: "php-api", script: '''sed -i 's#version: .*#version: #g' tests/etc/parameters.yml'''],
                 // Copy apache configuration for Kubernetes
                 [container: "httpd", script: "cp /home/jenkins/php-api-client/.ci/akeneo.conf /usr/local/apache2/conf/vhost.conf"],
                 // Reload apache (No restart otherwise pod will crash)

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ bin
 vendor
 composer.lock
 docker-compose.yml
-etc/parameters.yml
+tests/etc/parameters.yml
 phpspec.yml
 phpunit.xml
 .php_cs.cache

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -208,7 +208,7 @@ void runCheckoutClient(String phpVersion, String client, String psrImplem) {
                 sh "composer require ${client} ${psrImplem}"
                 sh "composer update --optimize-autoloader --no-interaction --no-progress --prefer-dist"
 
-                sh "cp etc/parameters.yml.dist etc/parameters.yml"
+                sh "cp tests/etc/parameters.yml.dist tests/etc/parameters.yml"
 
                 stash "php-api-client_${client}_${psrImplem}_php-${phpVersion}".replaceAll("/", "_")
             }
@@ -333,9 +333,9 @@ void runIntegrationTest(String phpVersion, String client, String psrImplem, Stri
 
             if ("2.0" == pimVersion) {
                 docker.image("akeneo/php:${phpVersion}").inside("--link akeneo-pim:akeneo-pim --link httpd:httpd -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker -w /home/docker/client --privileged") {
-                    sh "sed -i \"s#baseUri: .*#baseUri: 'http://httpd'#g\" etc/parameters.yml"
-                    sh "sed -i \"s#bin_path: .*#bin_path: bin#g\" etc/parameters.yml"
-                    sh "sed -i \"s#version: .*#version: #g\" etc/parameters.yml"
+                    sh "sed -i \"s#base_uri: .*#base_uri: 'http://httpd'#g\" tests/etc/parameters.yml"
+                    sh "sed -i \"s#bin_path: .*#bin_path: bin#g\" tests/etc/parameters.yml"
+                    sh "sed -i \"s#version: .*#version: #g\" tests/etc/parameters.yml"
                     sh "sudo ./bin/phpunit -c phpunit.xml.dist --testsuite PHP_Client_Unit_Test_2_0 --log-junit build/logs/phpunit_integration.xml"
                 }
             }

--- a/tests/Common/Api/ApiTestCase.php
+++ b/tests/Common/Api/ApiTestCase.php
@@ -45,21 +45,24 @@ abstract class ApiTestCase extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @param string $username
+     * @param string $password
+     *
      * @return AkeneoPimClientInterface
      */
-    protected function createClient()
+    protected function createClient($username = 'admin', $password = 'admin')
     {
         $config = $this->getConfiguration();
         $generator = new CredentialGenerator($this->getCommandLauncher());
 
         $credentials = $generator->generate($config['pim']['version']);
-        $clientBuilder = new AkeneoPimClientBuilder($config['api']['baseUri']);
+        $clientBuilder = new AkeneoPimClientBuilder($config['pim']['base_uri']);
 
         return $clientBuilder->buildAuthenticatedByPassword(
             $credentials['client_id'],
             $credentials['secret'],
-            $config['api']['credentials']['username'],
-            $config['api']['credentials']['password']
+            $username,
+            $password
         );
     }
 
@@ -99,6 +102,14 @@ abstract class ApiTestCase extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @return string
+     */
+    protected function getConfigurationFile()
+    {
+        return realpath(dirname(__FILE__)).'/../../../tests/etc/parameters.yml';
+    }
+
+    /**
      * @throws \RuntimeException
      *
      * @return array
@@ -113,14 +124,6 @@ abstract class ApiTestCase extends \PHPUnit_Framework_TestCase
         $config = Yaml::parse(file_get_contents($configFile));
 
         return $config;
-    }
-
-    /**
-     * @return string
-     */
-    protected function getConfigurationFile()
-    {
-        return realpath(dirname(__FILE__)).'/../../../etc/parameters.yml';
     }
 
     /**

--- a/tests/Common/Api/Attribute/ListAttributeIntegration.php
+++ b/tests/Common/Api/Attribute/ListAttributeIntegration.php
@@ -12,7 +12,7 @@ class ListAttributeIntegration extends ApiTestCase
     {
         $api = $this->createClient()->getAttributeApi();
         $expectedAttributes = $this->getExpectedAttributes();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(7);
         $this->assertInstanceOf(PageInterface::class, $firstPage);
@@ -62,7 +62,7 @@ class ListAttributeIntegration extends ApiTestCase
     public function testListPerPageWithCount()
     {
         $api = $this->createClient()->getAttributeApi();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(5, true);
         $this->assertInstanceOf(PageInterface::class, $firstPage);
@@ -74,7 +74,7 @@ class ListAttributeIntegration extends ApiTestCase
     {
         $api = $this->createClient()->getAttributeApi();
         $expectedAttributes = $this->getExpectedAttributes();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(2, false, ['foo' => 'bar']);
 
@@ -118,7 +118,7 @@ class ListAttributeIntegration extends ApiTestCase
      */
     protected function getExpectedAttributes()
     {
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         return [
             [

--- a/tests/Common/Api/AttributeOption/ListAttributeOptionIntegration.php
+++ b/tests/Common/Api/AttributeOption/ListAttributeOptionIntegration.php
@@ -12,7 +12,7 @@ class ListAttributeOptionIntegration extends ApiTestCase
     {
         $api = $this->createClient()->getAttributeOptionApi();
         $expectedAttributeOptions = $this->getExpectedAttributeOptions();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage('weather_conditions', 2);
         $this->assertInstanceOf(PageInterface::class, $firstPage);
@@ -60,7 +60,7 @@ class ListAttributeOptionIntegration extends ApiTestCase
     public function testListPerPageWithCount()
     {
         $api = $this->createClient()->getAttributeOptionApi();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage('weather_conditions',2, true);
         $this->assertInstanceOf(PageInterface::class, $firstPage);
@@ -72,7 +72,7 @@ class ListAttributeOptionIntegration extends ApiTestCase
     {
         $api = $this->createClient()->getAttributeOptionApi();
         $expectedAttributeOptions = $this->getExpectedAttributeOptions();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage('weather_conditions',2, false, ['foo' => 'bar']);
 
@@ -126,7 +126,7 @@ class ListAttributeOptionIntegration extends ApiTestCase
      */
     protected function getExpectedAttributeOptions()
     {
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         return [
             [

--- a/tests/Common/Api/Category/ListCategoryIntegration.php
+++ b/tests/Common/Api/Category/ListCategoryIntegration.php
@@ -12,7 +12,7 @@ class ListCategoryIntegration extends ApiTestCase
     {
         $api = $this->createClient()->getCategoryApi();
         $expectedCategories = $this->getExpectedCategories();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(2);
         $this->assertInstanceOf(PageInterface::class, $firstPage);
@@ -60,7 +60,7 @@ class ListCategoryIntegration extends ApiTestCase
     public function testListPerPageWithCount()
     {
         $api = $this->createClient()->getCategoryApi();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(2, true);
         $this->assertInstanceOf(PageInterface::class, $firstPage);
@@ -72,7 +72,7 @@ class ListCategoryIntegration extends ApiTestCase
     {
         $api = $this->createClient()->getCategoryApi();
         $expectedCategories = $this->getExpectedCategories();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(2, false, ['foo' => 'bar']);
 
@@ -116,7 +116,7 @@ class ListCategoryIntegration extends ApiTestCase
      */
     protected function getExpectedCategories()
     {
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         return [
             [

--- a/tests/Common/Api/Channel/ListChannelApiIntegration.php
+++ b/tests/Common/Api/Channel/ListChannelApiIntegration.php
@@ -11,7 +11,7 @@ class ListChannelApiIntegration extends ApiTestCase
     public function testListPerPage()
     {
         $api = $this->createClient()->getChannelAPi();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
         $expectedChannels = $this->getExpectedChannels();
 
         $firstPage = $api->listPerPage(1);
@@ -55,7 +55,7 @@ class ListChannelApiIntegration extends ApiTestCase
     public function testListPerPageWithCount()
     {
         $api = $this->createClient()->getChannelApi();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(1, true);
         $this->assertInstanceOf(PageInterface::class, $firstPage);
@@ -67,7 +67,7 @@ class ListChannelApiIntegration extends ApiTestCase
     {
         $api = $this->createClient()->getChannelApi();
         $expectedChannels = $this->getExpectedChannels();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(1, false, ['foo' => 'bar']);
 
@@ -110,7 +110,7 @@ class ListChannelApiIntegration extends ApiTestCase
      */
     public function getExpectedChannels()
     {
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         return [
             [

--- a/tests/Common/Api/Locale/ListLocaleApiIntegration.php
+++ b/tests/Common/Api/Locale/ListLocaleApiIntegration.php
@@ -12,7 +12,7 @@ class ListLocaleApiIntegration extends ApiTestCase
     {
         $api = $this->createClient()->getLocaleApi();
         $expectedLocales = $this->getExpectedLocales();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(3);
         $this->assertInstanceOf(PageInterface::class, $firstPage);
@@ -59,7 +59,7 @@ class ListLocaleApiIntegration extends ApiTestCase
     public function testListPerPageWithCount()
     {
         $api = $this->createClient()->getLocaleApi();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(3, true);
         $this->assertInstanceOf(PageInterface::class, $firstPage);
@@ -71,7 +71,7 @@ class ListLocaleApiIntegration extends ApiTestCase
     {
         $api = $this->createClient()->getLocaleApi();
         $expectedLocales = $this->getExpectedLocales();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(2, false, ['foo' => 'bar']);
 
@@ -162,7 +162,7 @@ class ListLocaleApiIntegration extends ApiTestCase
      */
     public function getExpectedLocales()
     {
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         return [
             [

--- a/tests/Common/Api/ProductMediaFile/CreateProductMediaFileApiIntegration.php
+++ b/tests/Common/Api/ProductMediaFile/CreateProductMediaFileApiIntegration.php
@@ -10,7 +10,7 @@ class CreateProductMediaFileApiIntegration extends ApiTestCase
     public function testCreateSuccessful()
     {
         $api = $this->createClient()->getProductMediaFileApi();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
         $mediaFile = realpath(__DIR__ . '/../../../fixtures/akeneo.png');
 
         $response = $api->create($mediaFile, [

--- a/tests/Common/Api/ProductMediaFile/GetProductMediaFileApiIntegration.php
+++ b/tests/Common/Api/ProductMediaFile/GetProductMediaFileApiIntegration.php
@@ -10,7 +10,7 @@ class GetProductMediaFileApiIntegration extends ApiTestCase
     {
         $api = $this->createClient()->getProductMediaFileApi();
         $code = $api->listPerPage(1)->getItems()[0]['code'];
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $mediaFile = $api->get($code);
         $this->assertInternalType('array', $mediaFile);

--- a/tests/Common/Api/ProductMediaFile/ListProductMediaFileApiIntegration.php
+++ b/tests/Common/Api/ProductMediaFile/ListProductMediaFileApiIntegration.php
@@ -13,7 +13,7 @@ class ListProductMediaFileApiIntegration extends ApiTestCase
     {
         $api = $this->createClient()->getProductMediaFileApi();
         $expectedMediaFiles = $this->getExpectedMediaFiles();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(2);
 
@@ -62,7 +62,7 @@ class ListProductMediaFileApiIntegration extends ApiTestCase
     public function testListPerPageWithCount()
     {
         $api = $this->createClient()->getProductMediaFileApi();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(2, true);
         $this->assertInstanceOf(PageInterface::class, $firstPage);
@@ -73,7 +73,7 @@ class ListProductMediaFileApiIntegration extends ApiTestCase
     public function testListPerPageWithSpecificQueryParameter()
     {
         $api = $this->createClient()->getProductMediaFileApi();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
         $expectedMediaFiles = $this->getExpectedMediaFiles();
 
         $firstPage = $api->listPerPage(2, false, ['foo' => 'bar']);
@@ -126,7 +126,7 @@ class ListProductMediaFileApiIntegration extends ApiTestCase
      */
     protected function getExpectedMediaFiles()
     {
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         return [
             $this->sanitizeMediaFile([

--- a/tests/etc/parameters.yml.dist
+++ b/tests/etc/parameters.yml.dist
@@ -1,10 +1,5 @@
-api:
-    baseUri: 'http://akeneo-pim'
-    credentials:
-        username: 'admin'
-        password: 'admin'
-
 pim:
+    base_uri: 'http://akeneo-pim'
     install_path: '/srv/pim'
     is_docker: true
     docker_name: akeneo-pim

--- a/tests/v1_7/Api/Family/ListFamilyApiIntegration.php
+++ b/tests/v1_7/Api/Family/ListFamilyApiIntegration.php
@@ -11,7 +11,7 @@ class ListFamilyApiIntegration extends ApiTestCase
     public function testListPerPage()
     {
         $api = $this->createClient()->getFamilyApi();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
         $expectedFamilies = $this->getExpectedFamilies();
 
         $firstPage = $api->listPerPage(2);
@@ -60,7 +60,7 @@ class ListFamilyApiIntegration extends ApiTestCase
     {
         $api = $this->createClient()->getFamilyApi();
         $expectedFamilies = $this->getExpectedFamilies();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(2, false, ['foo' => 'bar']);
 
@@ -104,7 +104,7 @@ class ListFamilyApiIntegration extends ApiTestCase
      */
     protected function getExpectedFamilies()
     {
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         return [
             [

--- a/tests/v1_7/Api/Product/ListProductApiIntegration.php
+++ b/tests/v1_7/Api/Product/ListProductApiIntegration.php
@@ -13,7 +13,7 @@ class ListProductApiIntegration extends AbstractProductApiTestCase
     {
         $api = $this->createClient()->getProductApi();
         $expectedProducts = $this->getExpectedProducts();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(5);
         $this->assertInstanceOf(PageInterface::class, $firstPage);
@@ -60,7 +60,7 @@ class ListProductApiIntegration extends AbstractProductApiTestCase
     public function testListPerPageWithCount()
     {
         $api = $this->createClient()->getProductApi();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(2, true);
         $this->assertInstanceOf(PageInterface::class, $firstPage);
@@ -72,7 +72,7 @@ class ListProductApiIntegration extends AbstractProductApiTestCase
     {
         $api = $this->createClient()->getProductApi();
         $expectedProducts = $this->getExpectedProducts();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(2, false, ['foo' => 'bar']);
 
@@ -180,7 +180,7 @@ class ListProductApiIntegration extends AbstractProductApiTestCase
 
     public function testAllWithSelectedLocales()
     {
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
         $api = $this->createClient()->getProductApi();
         $products = $api->all(10, [
             'locales' => 'fr_FR',
@@ -292,7 +292,7 @@ class ListProductApiIntegration extends AbstractProductApiTestCase
 
     public function testAllWithSelectedAttributes()
     {
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
         $api = $this->createClient()->getProductApi();
         $products = $api->all(1, ['attributes' => 'name,color']);
 
@@ -350,7 +350,7 @@ class ListProductApiIntegration extends AbstractProductApiTestCase
 
     public function testAllWithSelectedScope()
     {
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
         $api = $this->createClient()->getProductApi();
         $products = $api->all(10, [
             'scope' => 'mobile',
@@ -486,7 +486,7 @@ class ListProductApiIntegration extends AbstractProductApiTestCase
      */
     protected function getExpectedProducts()
     {
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         return [
             [

--- a/tests/v2_0/Api/AssociationType/ListAssociationTypeApiIntegration.php
+++ b/tests/v2_0/Api/AssociationType/ListAssociationTypeApiIntegration.php
@@ -11,7 +11,7 @@ class ListAssociationTypeApiIntegration extends ApiTestCase
     public function testListPerPage()
     {
         $api = $this->createClient()->getAssociationTypeApi();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
         $expectedAssociationTypes = $this->getExpectedAssociationTypes();
 
         $firstPage = $api->listPerPage(2);
@@ -57,7 +57,7 @@ class ListAssociationTypeApiIntegration extends ApiTestCase
     public function testListPerPageWithCount()
     {
         $api = $this->createClient()->getAssociationTypeApi();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(1, true);
         $this->assertInstanceOf(PageInterface::class, $firstPage);
@@ -69,7 +69,7 @@ class ListAssociationTypeApiIntegration extends ApiTestCase
     {
         $api = $this->createClient()->getAssociationTypeApi();
         $expectedAssociationTypes = $this->getExpectedAssociationTypes();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(1, false, ['foo' => 'bar']);
 
@@ -112,7 +112,7 @@ class ListAssociationTypeApiIntegration extends ApiTestCase
      */
     public function getExpectedAssociationTypes()
     {
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         return [
             [

--- a/tests/v2_0/Api/AttributeGroup/ListAttributeGroupIntegration.php
+++ b/tests/v2_0/Api/AttributeGroup/ListAttributeGroupIntegration.php
@@ -12,7 +12,7 @@ class ListAttributeGroupIntegration extends ApiTestCase
     {
         $api = $this->createClient()->getAttributeGroupApi();
         $expectedAttributeGroups = $this->getExpectedAttributeGroups();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(2);
         $this->assertInstanceOf(PageInterface::class, $firstPage);
@@ -63,7 +63,7 @@ class ListAttributeGroupIntegration extends ApiTestCase
     public function testListPerPageWithCount()
     {
         $api = $this->createClient()->getAttributeGroupApi();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(4, true);
         $this->assertInstanceOf(PageInterface::class, $firstPage);
@@ -75,7 +75,7 @@ class ListAttributeGroupIntegration extends ApiTestCase
     {
         $api = $this->createClient()->getAttributeGroupApi();
         $expectedAttributeGroups = $this->getExpectedAttributeGroups();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(2, false, ['foo' => 'bar']);
 
@@ -119,7 +119,7 @@ class ListAttributeGroupIntegration extends ApiTestCase
      */
     protected function getExpectedAttributeGroups()
     {
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         return [
             [

--- a/tests/v2_0/Api/Currency/ListCurrencyApiIntegration.php
+++ b/tests/v2_0/Api/Currency/ListCurrencyApiIntegration.php
@@ -12,7 +12,7 @@ class ListCurrencyApiIntegration extends ApiTestCase
     {
         $api = $this->createClient()->getCurrencyApi();
         $expectedCurrencies = $this->getExpectedCurrencies();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(3);
         $this->assertInstanceOf(PageInterface::class, $firstPage);
@@ -62,7 +62,7 @@ class ListCurrencyApiIntegration extends ApiTestCase
     public function testListPerPageWithCount()
     {
         $api = $this->createClient()->getCurrencyApi();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(7, true);
         $this->assertInstanceOf(PageInterface::class, $firstPage);
@@ -74,7 +74,7 @@ class ListCurrencyApiIntegration extends ApiTestCase
     {
         $api = $this->createClient()->getCurrencyApi();
         $expectedCurrencies = $this->getExpectedCurrencies();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(2, false, ['foo' => 'bar']);
 
@@ -118,7 +118,7 @@ class ListCurrencyApiIntegration extends ApiTestCase
      */
     public function getExpectedCurrencies()
     {
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         return [
             [

--- a/tests/v2_0/Api/Family/ListFamilyApiIntegration.php
+++ b/tests/v2_0/Api/Family/ListFamilyApiIntegration.php
@@ -11,7 +11,7 @@ class ListFamilyApiIntegration extends ApiTestCase
     public function testListPerPage()
     {
         $api = $this->createClient()->getFamilyApi();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
         $expectedFamilies = $this->getExpectedFamilies();
 
         $firstPage = $api->listPerPage(2);
@@ -60,7 +60,7 @@ class ListFamilyApiIntegration extends ApiTestCase
     {
         $api = $this->createClient()->getFamilyApi();
         $expectedFamilies = $this->getExpectedFamilies();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(2, false, ['foo' => 'bar']);
 
@@ -104,7 +104,7 @@ class ListFamilyApiIntegration extends ApiTestCase
      */
     protected function getExpectedFamilies()
     {
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         return [
             [

--- a/tests/v2_0/Api/FamilyVariant/ListFamilyVariantApiIntegration.php
+++ b/tests/v2_0/Api/FamilyVariant/ListFamilyVariantApiIntegration.php
@@ -11,7 +11,7 @@ class ListFamilyVariantApiIntegration extends ApiTestCase
     public function testListPerPage()
     {
         $api = $this->createClient()->getFamilyVariantApi();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
         $expectedFamilyVariants = $this->getExpectedFamilyVariants();
 
         $firstPage = $api->listPerPage('boots', 2);
@@ -87,7 +87,7 @@ class ListFamilyVariantApiIntegration extends ApiTestCase
      */
     protected function getExpectedFamilyVariants()
     {
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         return [
             [

--- a/tests/v2_0/Api/MeasureFamily/ListMeasureFamilyIntegration.php
+++ b/tests/v2_0/Api/MeasureFamily/ListMeasureFamilyIntegration.php
@@ -11,7 +11,7 @@ class ListMeasureFamilyIntegration extends ApiTestCase
     public function testListPerPage()
     {
         $api = $this->createClient()->getMeasureFamilyApi();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
         $expectedMeasureFamilies = $this->getExpectedMeasureFamilies();
 
         $firstPage = $api->listPerPage(5);
@@ -77,7 +77,7 @@ class ListMeasureFamilyIntegration extends ApiTestCase
     public function testListPerPageWithCount()
     {
         $api = $this->createClient()->getMeasureFamilyApi();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(10, true);
         $this->assertInstanceOf(PageInterface::class, $firstPage);
@@ -89,7 +89,7 @@ class ListMeasureFamilyIntegration extends ApiTestCase
     {
         $api = $this->createClient()->getMeasureFamilyApi();
         $expectedMeasureFamilies = $this->getExpectedMeasureFamilies();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(1, false, ['foo' => 'bar']);
 
@@ -129,7 +129,7 @@ class ListMeasureFamilyIntegration extends ApiTestCase
 
     public function getExpectedMeasureFamilies()
     {
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         return [
             [

--- a/tests/v2_0/Api/Product/ListProductApiIntegration.php
+++ b/tests/v2_0/Api/Product/ListProductApiIntegration.php
@@ -13,7 +13,7 @@ class ListProductApiIntegration extends AbstractProductApiTestCase
     {
         $api = $this->createClient()->getProductApi();
         $expectedProducts = $this->getExpectedProducts();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(5);
         $this->assertInstanceOf(PageInterface::class, $firstPage);
@@ -60,7 +60,7 @@ class ListProductApiIntegration extends AbstractProductApiTestCase
     public function testListPerPageWithCount()
     {
         $api = $this->createClient()->getProductApi();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(2, true);
         $this->assertInstanceOf(PageInterface::class, $firstPage);
@@ -72,7 +72,7 @@ class ListProductApiIntegration extends AbstractProductApiTestCase
     {
         $api = $this->createClient()->getProductApi();
         $expectedProducts = $this->getExpectedProducts();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(2, false, ['foo' => 'bar']);
 
@@ -181,7 +181,7 @@ class ListProductApiIntegration extends AbstractProductApiTestCase
 
     public function testAllWithSelectedLocales()
     {
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
         $api = $this->createClient()->getProductApi();
         $products = $api->all(10, [
             'locales' => 'fr_FR',
@@ -292,7 +292,7 @@ class ListProductApiIntegration extends AbstractProductApiTestCase
 
     public function testAllWithSelectedAttributes()
     {
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
         $api = $this->createClient()->getProductApi();
         $products = $api->all(1, ['attributes' => 'name,color']);
 
@@ -349,7 +349,7 @@ class ListProductApiIntegration extends AbstractProductApiTestCase
 
     public function testAllWithSelectedScope()
     {
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
         $api = $this->createClient()->getProductApi();
         $products = $api->all(10, [
             'scope' => 'mobile',
@@ -484,8 +484,8 @@ class ListProductApiIntegration extends AbstractProductApiTestCase
      */
     protected function getExpectedProducts()
     {
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
-        
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
+
         return [
             [
                 '_links'        => [

--- a/tests/v2_0/Api/ProductModel/ListProductModelApiIntegration.php
+++ b/tests/v2_0/Api/ProductModel/ListProductModelApiIntegration.php
@@ -12,7 +12,7 @@ class ListProductModelApiIntegration extends AbstractProductApiTestCase
     {
         $api = $this->createClient()->getProductModelApi();
         $expectedProductModels = $this->getExpectedProductModels();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(2);
         $this->assertInstanceOf(PageInterface::class, $firstPage);
@@ -71,7 +71,7 @@ class ListProductModelApiIntegration extends AbstractProductApiTestCase
     public function testListPerPageWithCount()
     {
         $api = $this->createClient()->getProductModelApi();
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         $firstPage = $api->listPerPage(2, true);
         $this->assertInstanceOf(PageInterface::class, $firstPage);
@@ -97,7 +97,7 @@ class ListProductModelApiIntegration extends AbstractProductApiTestCase
 
     protected function getExpectedProductModels()
     {
-        $baseUri = $this->getConfiguration()['api']['baseUri'];
+        $baseUri = $this->getConfiguration()['pim']['base_uri'];
 
         return [
             [


### PR DESCRIPTION
This PR:
- removes two useless parameters: `pim.username` and `pim.password`, as in the EE client, we need to incarnate different users, sometime in the same scenario,
- moves the `etc/parameters.yml` in `tests` folder, as this configuration file is only used for tests,
- put all parameters under the prefix `pim` (no more `api`).