### PR TITLE
API-487: Isolate files manipulation in a dedicated service

### DIFF
--- a/src/Api/ProductMediaFileApi.php
+++ b/src/Api/ProductMediaFileApi.php
@@ -4,6 +4,7 @@ namespace Akeneo\Pim\ApiClient\Api;
 
 use Akeneo\Pim\ApiClient\Client\ResourceClientInterface;
 use Akeneo\Pim\ApiClient\Exception\RuntimeException;
+use Akeneo\Pim\ApiClient\FileSystem\FileSystemInterface;
 use Akeneo\Pim\ApiClient\Pagination\PageFactoryInterface;
 use Akeneo\Pim\ApiClient\Pagination\ResourceCursorFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -31,19 +32,25 @@ class ProductMediaFileApi implements MediaFileApiInterface
     /** @var ResourceCursorFactoryInterface */
     protected $cursorFactory;
 
+    /** @var FileSystemInterface */
+    private $fileSystem;
+
     /**
      * @param ResourceClientInterface        $resourceClient
      * @param PageFactoryInterface           $pageFactory
      * @param ResourceCursorFactoryInterface $cursorFactory
+     * @param FileSystemInterface            $fileSystem
      */
     public function __construct(
         ResourceClientInterface $resourceClient,
         PageFactoryInterface $pageFactory,
-        ResourceCursorFactoryInterface $cursorFactory
+        ResourceCursorFactoryInterface $cursorFactory,
+        FileSystemInterface $fileSystem
     ) {
         $this->resourceClient = $resourceClient;
         $this->pageFactory = $pageFactory;
         $this->cursorFactory = $cursorFactory;
+        $this->fileSystem = $fileSystem;
     }
 
     /**
@@ -80,11 +87,7 @@ class ProductMediaFileApi implements MediaFileApiInterface
     public function create($mediaFile, array $productData)
     {
         if (is_string($mediaFile)) {
-            if (!is_readable($mediaFile)) {
-                throw new RuntimeException(sprintf('The file "%s" could not be read.', $mediaFile));
-            }
-
-            $mediaFile = fopen($mediaFile, 'rb');
+            $mediaFile = $this->fileSystem->getResourceFromPath($mediaFile);
         }
 
         $requestParts = [

--- a/src/Exception/UnreadableFileException.php
+++ b/src/Exception/UnreadableFileException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Akeneo\Pim\ApiClient\Exception;
+
+/**
+ * Exception thrown when a file can not be read.
+ *
+ * @author    Laurent Petard <laurent.petard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class UnreadableFileException extends RuntimeException
+{
+}

--- a/src/FileSystem/FileSystemInterface.php
+++ b/src/FileSystem/FileSystemInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Akeneo\Pim\ApiClient\FileSystem;
+
+use Akeneo\Pim\ApiClient\Exception\UnreadableFileException;
+
+/**
+ * Manipulates files for the API.
+ *
+ * @author    Laurent Petard <laurent.petard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface FileSystemInterface
+{
+    /**
+     * Gets the resource of a file from its path.
+     *
+     * @param string $filePath Path of the file
+     *
+     * @throws UnreadableFileException if the file doesn't exists or is not readable
+     *
+     * @return resource
+     */
+    public function getResourceFromPath($filePath);
+}

--- a/src/FileSystem/LocalFileSystem.php
+++ b/src/FileSystem/LocalFileSystem.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Akeneo\Pim\ApiClient\FileSystem;
+
+use Akeneo\Pim\ApiClient\Exception\UnreadableFileException;
+
+/**
+ * File system to manipulate files stored locally.
+ *
+ * @author    Laurent Petard <laurent.petard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class LocalFileSystem implements FileSystemInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getResourceFromPath($filePath)
+    {
+        if (!is_readable($filePath)) {
+            throw new UnreadableFileException(sprintf('The file "%s" could not be read.', $filePath));
+        }
+
+        $fileResource = fopen($filePath, 'rb');
+
+        if (!is_resource($fileResource)) {
+            throw new \RuntimeException(sprintf('The file "%s" could not be opened.', $filePath));
+        }
+
+        return $fileResource;
+    }
+}

--- a/tests/Common/Api/ProductMediaFile/CreateProductMediaFileApiIntegration.php
+++ b/tests/Common/Api/ProductMediaFile/CreateProductMediaFileApiIntegration.php
@@ -88,6 +88,21 @@ class CreateProductMediaFileApiIntegration extends ApiTestCase
     }
 
     /**
+     * @expectedException \Akeneo\Pim\ApiClient\Exception\UnreadableFileException
+     */
+    public function testCreateWithAnInvalidFile()
+    {
+        $api = $this->createClient()->getProductMediaFileApi();
+
+        $api->create('foo.jpg', [
+            'identifier' => 'medium_boot',
+            'attribute'  => 'side_view',
+            'scope'      => null,
+            'locale'     => null,
+        ]);
+    }
+
+    /**
      * Sanitize the code and links of a media file, because the code is generated randomly.
      *
      * @param array $mediaFile


### PR DESCRIPTION
The goal is to avoid to execute `fopen` and handle errors directly in API services.
  
  