### PR TITLE
API-562: upsert a list of attribute options

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -385,6 +385,9 @@ def runPim2IntegrationTest(String phpVersion, String client, String psrImplem, S
         def files = []
 
         // Find and store PHP test integration files to launch them in parallels
+        if ("2.1" == pimVersion) {
+            files += sh (returnStdout: true, script: 'find /home/jenkins/php-api-client/tests/v2_1/Api -name "*Integration.php"').tokenize('\n')
+        }
         files += sh (returnStdout: true, script: 'find /home/jenkins/php-api-client/tests/v2_0/Api -name "*Integration.php"').tokenize('\n')
         files += sh (returnStdout: true, script: 'find /home/jenkins/php-api-client/tests/Common/Api -name "*Integration.php"').tokenize('\n')
         for (file in files) {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,7 +25,7 @@
         <directory suffix="Integration.php">tests/v2_0/Api/*</directory>
     </testsuite>
 
-    <testsuite name="PHP_Client_Unit_Test_2_1">
+    <testsuite name="PHP_Client_Test_2_1">
         <directory suffix="Integration.php">tests/Common/Api/*</directory>
         <directory suffix="Integration.php">tests/v2_0/Api/*</directory>
         <directory suffix="Integration.php">tests/v2_1/Api/*</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,4 +25,10 @@
         <directory suffix="Integration.php">tests/v2_0/Api/*</directory>
     </testsuite>
 
+    <testsuite name="PHP_Client_Unit_Test_2_1">
+        <directory suffix="Integration.php">tests/Common/Api/*</directory>
+        <directory suffix="Integration.php">tests/v2_0/Api/*</directory>
+        <directory suffix="Integration.php">tests/v2_1/Api/*</directory>
+    </testsuite>
+
 </phpunit>

--- a/spec/Api/AttributeOptionApiSpec.php
+++ b/spec/Api/AttributeOptionApiSpec.php
@@ -10,6 +10,7 @@ use Akeneo\Pim\ApiClient\Pagination\PageFactoryInterface;
 use Akeneo\Pim\ApiClient\Pagination\PageInterface;
 use Akeneo\Pim\ApiClient\Pagination\ResourceCursorFactoryInterface;
 use Akeneo\Pim\ApiClient\Pagination\ResourceCursorInterface;
+use Akeneo\Pim\ApiClient\Stream\UpsertResourceListResponse;
 use PhpSpec\ObjectBehavior;
 
 class AttributeOptionApiSpec extends ObjectBehavior
@@ -148,5 +149,18 @@ class AttributeOptionApiSpec extends ObjectBehavior
         $this
             ->upsert('foo', 'bar', ['code' => 'bar', 'attribute' => 'foo', 'sort_order' => 42])
             ->shouldReturn(204);
+    }
+
+    function it_upserts_a_list_of_attribute_options($resourceClient, UpsertResourceListResponse $response)
+    {
+        $resourceClient->upsertResourceList(AttributeOptionApi::ATTRIBUTE_OPTIONS_URI, ['foo'], [
+            ['code' => 'bar', 'attribute' => 'foo', 'sort_order' => 42],
+            ['code' => 'fighters', 'attribute' => 'foo', 'sort_order' => 43]
+        ])->willReturn($response);
+
+        $this->upsertList('foo', [
+            ['code' => 'bar', 'attribute' => 'foo', 'sort_order' => 42],
+            ['code' => 'fighters', 'attribute' => 'foo', 'sort_order' => 43]
+        ])->shouldReturn($response);
     }
 }

--- a/src/Api/AttributeOptionApi.php
+++ b/src/Api/AttributeOptionApi.php
@@ -98,4 +98,12 @@ class AttributeOptionApi implements AttributeOptionApiInterface
     {
         return $this->resourceClient->upsertResource(static::ATTRIBUTE_OPTION_URI, [$attributeCode, $attributeOptionCode], $data);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function upsertList($attributeCode, $attributeOptions)
+    {
+        return $this->resourceClient->upsertResourceList(static::ATTRIBUTE_OPTIONS_URI, [$attributeCode], $attributeOptions);
+    }
 }

--- a/src/Api/AttributeOptionApiInterface.php
+++ b/src/Api/AttributeOptionApiInterface.php
@@ -85,4 +85,16 @@ interface AttributeOptionApiInterface
      * @return int returns either http code 201 if the attribute option has been created or 204 if it has been updated
      */
     public function upsert($attributeCode, $attributeOptionCode, array $data = []);
+
+    /**
+     * Updates or creates several attribute options at once.
+     *
+     * @param string                $attributeCode    code of the attribute
+     * @param array|StreamInterface $attributeOptions array or StreamInterface object containing data of the attribute options to create or update
+     *
+     * @throws HttpException
+     *
+     * @return \Traversable returns an iterable object, each entry corresponding to the response of the upserted attribute options
+     */
+    public function upsertList($attributeCode, $attributeOptions);
 }

--- a/tests/v2_1/Api/AttributeOption/UpsertListAttributeOptionIntegration.php
+++ b/tests/v2_1/Api/AttributeOption/UpsertListAttributeOptionIntegration.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Akeneo\Pim\ApiClient\tests\v2_1\Api\AttributeOption;
+
+use Akeneo\Pim\ApiClient\tests\Common\Api\ApiTestCase;
+
+class UpsertListAttributeOptionIntegration extends ApiTestCase
+{
+    public function testUpsertListSuccessful()
+    {
+        $api = $this->createClient()->getAttributeOptionApi();
+        $response = $api->upsertList('weather_conditions', [
+            [
+                'code'       => 'hot',
+                'attribute'  => 'weather_conditions',
+                'sort_order' => 34,
+                'labels'     => [
+                    'en_US' => 'Hot!',
+                ],
+            ],
+            [
+                'code'       => 'cloudy',
+                'attribute'  => 'weather_conditions',
+                'sort_order' => 35,
+                'labels'     => [
+                    'en_US' => 'Cloudy',
+                ],
+
+            ],
+        ]);
+
+        $this->assertInstanceOf('\Iterator', $response);
+
+        $responseLines = iterator_to_array($response);
+        $this->assertCount(2, $responseLines);
+
+        $this->assertSame([
+            'line'        => 1,
+            'code'        => 'hot',
+            'status_code' => 204,
+        ], $responseLines[1]);
+
+        $this->assertSame([
+            'line'        => 2,
+            'code'        => 'cloudy',
+            'status_code' => 201,
+        ], $responseLines[2]);
+    }
+
+    public function testUpsertListFailed()
+    {
+        $api = $this->createClient()->getAttributeOptionApi();
+        $response = $api->upsertList('weather_conditions', [
+            [
+                'attribute'  => 'weather_conditions',
+                'sort_order' => 34,
+                'labels'     => [
+                    'en_US' => 'Hot!',
+                ],
+            ],
+            [
+                'code'       => 'cloudy!',
+                'attribute'  => 'weather_conditions',
+                'sort_order' => 35,
+                'labels'     => [
+                    'en_US' => 'Cloudy',
+                ],
+
+            ],
+        ]);
+
+        $this->assertInstanceOf('\Iterator', $response);
+
+        $responseLines = iterator_to_array($response);
+        $this->assertCount(2, $responseLines);
+
+        $this->assertSame([
+            'line'        => 1,
+            'status_code' => 422,
+            'message'     => 'Code is missing.',
+        ], $responseLines[1]);
+
+        $this->assertSame([
+            'line'        => 2,
+            'code'        => 'cloudy!',
+            'status_code' => 422,
+            'message' => 'Validation failed.',
+            'errors' => [[
+                'property' => 'code',
+                'message' => 'Option code may contain only letters, numbers and underscores'
+            ]]
+        ], $responseLines[2]);
+    }
+}


### PR DESCRIPTION
  I added a PhpUnit test suite for 2.1 PIM that includes the 2.0 tests. It's not ideal but we have to think to a better way to organize integration tests per PIM version, and it will be done in another PR
  