### PR TITLE
Refactor upsert list

### DIFF
--- a/spec/Api/AssociationTypeApiSpec.php
+++ b/spec/Api/AssociationTypeApiSpec.php
@@ -149,7 +149,7 @@ class AssociationTypeApiSpec extends ObjectBehavior
     function it_upserts_a_list_of_association_types($resourceClient, UpsertResourceListResponse $response)
     {
         $resourceClient
-            ->upsertResourceList(
+            ->upsertStreamResourceList(
                 AssociationTypeApi::ASSOCIATION_TYPES_URI,
                 [],
                 [

--- a/spec/Api/AttributeApiSpec.php
+++ b/spec/Api/AttributeApiSpec.php
@@ -143,7 +143,7 @@ class AttributeApiSpec extends ObjectBehavior
     function it_upserts_a_list_of_attributes($resourceClient, UpsertResourceListResponse $response)
     {
         $resourceClient
-            ->upsertResourceList(
+            ->upsertStreamResourceList(
                 AttributeApi::ATTRIBUTES_URI,
                 [],
                 [

--- a/spec/Api/AttributeGroupApiSpec.php
+++ b/spec/Api/AttributeGroupApiSpec.php
@@ -141,7 +141,7 @@ class AttributeGroupApiSpec extends ObjectBehavior
     function it_upserts_a_list_of_attribute_groups($resourceClient, UpsertResourceListResponse $response)
     {
         $resourceClient
-            ->upsertResourceList(
+            ->upsertStreamResourceList(
                 AttributeGroupApi::ATTRIBUTE_GROUPS_URI,
                 [],
                 [

--- a/spec/Api/AttributeOptionApiSpec.php
+++ b/spec/Api/AttributeOptionApiSpec.php
@@ -153,7 +153,7 @@ class AttributeOptionApiSpec extends ObjectBehavior
 
     function it_upserts_a_list_of_attribute_options($resourceClient, UpsertResourceListResponse $response)
     {
-        $resourceClient->upsertResourceList(AttributeOptionApi::ATTRIBUTE_OPTIONS_URI, ['foo'], [
+        $resourceClient->upsertStreamResourceList(AttributeOptionApi::ATTRIBUTE_OPTIONS_URI, ['foo'], [
             ['code' => 'bar', 'attribute' => 'foo', 'sort_order' => 42],
             ['code' => 'fighters', 'attribute' => 'foo', 'sort_order' => 43]
         ])->willReturn($response);

--- a/spec/Api/CategoryApiSpec.php
+++ b/spec/Api/CategoryApiSpec.php
@@ -139,7 +139,7 @@ class CategoryApiSpec extends ObjectBehavior
     function it_upserts_a_list_of_categories($resourceClient, UpsertResourceListResponse $response)
     {
         $resourceClient
-            ->upsertResourceList(
+            ->upsertStreamResourceList(
                 CategoryApi::CATEGORIES_URI,
                 [],
                 [

--- a/spec/Api/ChannelApiSpec.php
+++ b/spec/Api/ChannelApiSpec.php
@@ -143,7 +143,7 @@ class ChannelApiSpec extends ObjectBehavior
     function it_upserts_a_list_of_channel($resourceClient, UpsertResourceListResponse $response)
     {
         $resourceClient
-            ->upsertResourceList(
+            ->upsertStreamResourceList(
                 ChannelApi::CHANNELS_URI,
                 [],
                 [

--- a/spec/Api/FamilyApiSpec.php
+++ b/spec/Api/FamilyApiSpec.php
@@ -142,7 +142,7 @@ class FamilyApiSpec extends ObjectBehavior
     function it_upserts_a_list_of_families($resourceClient, UpsertResourceListResponse $response)
     {
         $resourceClient
-            ->upsertResourceList(
+            ->upsertStreamResourceList(
                 FamilyApi::FAMILIES_URI,
                 [],
                 [

--- a/spec/Api/FamilyVariantApiSpec.php
+++ b/spec/Api/FamilyVariantApiSpec.php
@@ -210,7 +210,7 @@ class FamilyVariantApiSpec extends ObjectBehavior
         ];
 
         $resourceClient
-            ->upsertResourceList(FamilyVariantApi::FAMILY_VARIANTS_URI, ['boots'], $data)
+            ->upsertStreamResourceList(FamilyVariantApi::FAMILY_VARIANTS_URI, ['boots'], $data)
             ->willReturn($response);
 
         $this->upsertList('boots', $data)->shouldReturn($response);

--- a/spec/Api/ProductApiSpec.php
+++ b/spec/Api/ProductApiSpec.php
@@ -153,7 +153,7 @@ class ProductApiSpec extends ObjectBehavior
     function it_upserts_a_list_of_products($resourceClient, UpsertResourceListResponse $response)
     {
         $resourceClient
-            ->upsertResourceList(
+            ->upsertStreamResourceList(
                 ProductApi::PRODUCTS_URI,
                 [],
                 [

--- a/spec/Api/ProductModelApiSpec.php
+++ b/spec/Api/ProductModelApiSpec.php
@@ -151,7 +151,7 @@ class ProductModelApiSpec extends ObjectBehavior
             ]
         ];
 
-        $resourceClient->upsertResourceList(ProductModelApi::PRODUCT_MODELS_URI, [], $data)->willReturn($response);
+        $resourceClient->upsertStreamResourceList(ProductModelApi::PRODUCT_MODELS_URI, [], $data)->willReturn($response);
 
         $this->upsertList($data)->shouldReturn($response);
     }

--- a/spec/Client/ResourceClientSpec.php
+++ b/spec/Client/ResourceClientSpec.php
@@ -231,7 +231,7 @@ JSON;
         $responseFactory->create($responseBodyStream)->willReturn($listResponse);
 
         $this
-            ->upsertResourceList(
+            ->upsertStreamResourceList(
                 'api/rest/v1/categories',
                 [],
                 [
@@ -271,7 +271,7 @@ JSON;
         $responseFactory->create($responseBodyStream)->willReturn($listResponse);
 
         $this
-            ->upsertResourceList('api/rest/v1/categories', [], $resourcesStream)
+            ->upsertStreamResourceList('api/rest/v1/categories', [], $resourcesStream)
             ->shouldReturn($listResponse);
     }
 
@@ -293,7 +293,7 @@ JSON;
     {
         $this
             ->shouldthrow(new InvalidArgumentException('The parameter "resources" must be an array or an instance of StreamInterface.'))
-            ->during('upsertResourceList', ['api/rest/v1/categories', [], 'foo']);
+            ->during('upsertStreamResourceList', ['api/rest/v1/categories', [], 'foo']);
     }
 
     function it_creates_a_multipart_resource(

--- a/src/Api/AssociationTypeApi.php
+++ b/src/Api/AssociationTypeApi.php
@@ -95,6 +95,6 @@ class AssociationTypeApi implements AssociationTypeApiInterface
      */
     public function upsertList($associationTypes)
     {
-        return $this->resourceClient->upsertResourceList(static::ASSOCIATION_TYPES_URI, [], $associationTypes);
+        return $this->resourceClient->upsertStreamResourceList(static::ASSOCIATION_TYPES_URI, [], $associationTypes);
     }
 }

--- a/src/Api/AttributeApi.php
+++ b/src/Api/AttributeApi.php
@@ -98,6 +98,6 @@ class AttributeApi implements AttributeApiInterface
      */
     public function upsertList($attributes)
     {
-        return $this->resourceClient->upsertResourceList(static::ATTRIBUTES_URI, [], $attributes);
+        return $this->resourceClient->upsertStreamResourceList(static::ATTRIBUTES_URI, [], $attributes);
     }
 }

--- a/src/Api/AttributeGroupApi.php
+++ b/src/Api/AttributeGroupApi.php
@@ -100,6 +100,6 @@ class AttributeGroupApi implements AttributeGroupApiInterface
      */
     public function upsertList($attributeGroups)
     {
-        return $this->resourceClient->upsertResourceList(static::ATTRIBUTE_GROUPS_URI, [], $attributeGroups);
+        return $this->resourceClient->upsertStreamResourceList(static::ATTRIBUTE_GROUPS_URI, [], $attributeGroups);
     }
 }

--- a/src/Api/AttributeOptionApi.php
+++ b/src/Api/AttributeOptionApi.php
@@ -104,6 +104,6 @@ class AttributeOptionApi implements AttributeOptionApiInterface
      */
     public function upsertList($attributeCode, $attributeOptions)
     {
-        return $this->resourceClient->upsertResourceList(static::ATTRIBUTE_OPTIONS_URI, [$attributeCode], $attributeOptions);
+        return $this->resourceClient->upsertStreamResourceList(static::ATTRIBUTE_OPTIONS_URI, [$attributeCode], $attributeOptions);
     }
 }

--- a/src/Api/CategoryApi.php
+++ b/src/Api/CategoryApi.php
@@ -98,6 +98,6 @@ class CategoryApi implements CategoryApiInterface
      */
     public function upsertList($categories)
     {
-        return $this->resourceClient->upsertResourceList(static::CATEGORIES_URI, [], $categories);
+        return $this->resourceClient->upsertStreamResourceList(static::CATEGORIES_URI, [], $categories);
     }
 }

--- a/src/Api/ChannelApi.php
+++ b/src/Api/ChannelApi.php
@@ -98,6 +98,6 @@ class ChannelApi implements ChannelApiInterface
      */
     public function upsertList($channels)
     {
-        return $this->resourceClient->upsertResourceList(static::CHANNELS_URI, [], $channels);
+        return $this->resourceClient->upsertStreamResourceList(static::CHANNELS_URI, [], $channels);
     }
 }

--- a/src/Api/FamilyApi.php
+++ b/src/Api/FamilyApi.php
@@ -98,6 +98,6 @@ class FamilyApi implements FamilyApiInterface
      */
     public function upsertList($families)
     {
-        return $this->resourceClient->upsertResourceList(static::FAMILIES_URI, [], $families);
+        return $this->resourceClient->upsertStreamResourceList(static::FAMILIES_URI, [], $families);
     }
 }

--- a/src/Api/FamilyVariantApi.php
+++ b/src/Api/FamilyVariantApi.php
@@ -114,6 +114,6 @@ class FamilyVariantApi implements FamilyVariantApiInterface
      */
     public function upsertList($familyCode, $familyVariants)
     {
-        return $this->resourceClient->upsertResourceList(static::FAMILY_VARIANTS_URI, [$familyCode], $familyVariants);
+        return $this->resourceClient->upsertStreamResourceList(static::FAMILY_VARIANTS_URI, [$familyCode], $familyVariants);
     }
 }

--- a/src/Api/ProductApi.php
+++ b/src/Api/ProductApi.php
@@ -108,6 +108,6 @@ class ProductApi implements ProductApiInterface
      */
     public function upsertList($products)
     {
-        return $this->resourceClient->upsertResourceList(static::PRODUCTS_URI, [], $products);
+        return $this->resourceClient->upsertStreamResourceList(static::PRODUCTS_URI, [], $products);
     }
 }

--- a/src/Api/ProductModelApi.php
+++ b/src/Api/ProductModelApi.php
@@ -120,6 +120,6 @@ class ProductModelApi implements ProductModelApiInterface
      */
     public function upsertList($productModels)
     {
-        return $this->resourceClient->upsertResourceList(static::PRODUCT_MODELS_URI, [], $productModels);
+        return $this->resourceClient->upsertStreamResourceList(static::PRODUCT_MODELS_URI, [], $productModels);
     }
 }

--- a/src/Client/ResourceClient.php
+++ b/src/Client/ResourceClient.php
@@ -1,8 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Akeneo\Pim\ApiClient\Client;
 
 use Akeneo\Pim\ApiClient\Exception\InvalidArgumentException;
+use Akeneo\Pim\ApiClient\Exception\RuntimeException;
 use Akeneo\Pim\ApiClient\Routing\UriGeneratorInterface;
 use Akeneo\Pim\ApiClient\Stream\MultipartStreamBuilderFactory;
 use Akeneo\Pim\ApiClient\Stream\UpsertResourceListResponseFactory;
@@ -180,6 +183,27 @@ class ResourceClient implements ResourceClientInterface
         );
 
         return $this->upsertListResponseFactory->create($response->getBody());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function upsertJsonResourceList(string $uri, array $uriParameters = [], array $resources = []): array
+    {
+        $uri = $this->uriGenerator->generate($uri, $uriParameters);
+        $response = $this->httpClient->sendRequest(
+            'PATCH',
+            $uri,
+            ['Content-Type' => 'application/json'],
+            json_encode($resources)
+        );
+
+        $response = json_decode($response->getBody()->getContents(), true);
+        if (!is_array($response)) {
+            throw new RuntimeException('The server response is not a valid JSON');
+        }
+
+        return $response;
     }
 
     /**

--- a/src/Client/ResourceClient.php
+++ b/src/Client/ResourceClient.php
@@ -150,7 +150,7 @@ class ResourceClient implements ResourceClientInterface
     /**
      * {@inheritdoc}
      */
-    public function upsertResourceList($uri, array $uriParameters = [], $resources = [])
+    public function upsertStreamResourceList($uri, array $uriParameters = [], $resources = [])
     {
         if (!is_array($resources) && !$resources instanceof StreamInterface) {
             throw new InvalidArgumentException('The parameter "resources" must be an array or an instance of StreamInterface.');

--- a/src/Client/ResourceClientInterface.php
+++ b/src/Client/ResourceClientInterface.php
@@ -90,7 +90,7 @@ interface ResourceClientInterface
     public function upsertResource($uri, array $uriParameters = [], array $body = []);
 
     /**
-     * Updates or creates several resources.
+     * Updates or creates several resources using a stream.
      *
      * @param string                $uri           URI of the resource
      * @param array                 $uriParameters URI parameters of the resource
@@ -102,7 +102,7 @@ interface ResourceClientInterface
      *
      * @return \Traversable returns an iterable object, each entry corresponding to the response of the upserted resource
      */
-    public function upsertResourceList($uri, array $uriParameters = [], $resources = []);
+    public function upsertStreamResourceList($uri, array $uriParameters = [], $resources = []);
 
     /**
      * Deletes a resource.

--- a/src/Client/ResourceClientInterface.php
+++ b/src/Client/ResourceClientInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Akeneo\Pim\ApiClient\Client;
 
 use Akeneo\Pim\ApiClient\Exception\HttpException;
@@ -90,7 +92,7 @@ interface ResourceClientInterface
     public function upsertResource($uri, array $uriParameters = [], array $body = []);
 
     /**
-     * Updates or creates several resources using a stream.
+     * Updates or creates several resources using a stream for the request and the response.
      *
      * @param string                $uri           URI of the resource
      * @param array                 $uriParameters URI parameters of the resource
@@ -103,6 +105,20 @@ interface ResourceClientInterface
      * @return \Traversable returns an iterable object, each entry corresponding to the response of the upserted resource
      */
     public function upsertStreamResourceList($uri, array $uriParameters = [], $resources = []);
+
+    /**
+     * Updates or creates several resources using a single JSON string for the request and the response.
+     *
+     * @param string $uri           URI of the resource
+     * @param array  $uriParameters URI parameters of the resource
+     * @param array  $resources     array of resources to create or update.
+     *
+     * @throws HttpException            If the request failed.
+     * @throws InvalidArgumentException If the resources or any part thereof are invalid.
+     *
+     * @return array
+     */
+    public function upsertJsonResourceList(string $uri, array $uriParameters = [], array $resources = []): array;
 
     /**
      * Deletes a resource.


### PR DESCRIPTION
With the end-points of the reference entities, we changed the way of patching resources. The requests bodies are a single JSON instead of bodies containing one JSON per line. Same for the responses.

So I added a method in the resource client to be able to patch several resources using only one JSON for the request and the response.
I renamed the method `upsertResourceList` to avoid any confusion.