### PR TITLE
Use the right version of guzzle for the CI with PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
     - composer self-update --no-interaction
 
 install:
-    - composer require php-http/guzzle6-adapter
+    - composer require php-http/guzzle6-adapter ^1.1
     - composer install --prefer-dist --no-interaction
 
 script:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ curl -s http://getcomposer.org/installer | php
 
 Then, run the following command to require the library:
 ```bash
-$ php composer.phar require akeneo/api-php-client php-http/guzzle6-adapter
+$ php composer.phar require akeneo/api-php-client php-http/guzzle6-adapter ^1.1
 ```
 
 If you want to use another HTTP client implementation, you can check [here](https://packagist.org/providers/php-http/client-implementation) the full list of HTTP client implementations. 


### PR DESCRIPTION
For PHP 7.1 composer tries to require php-http/guzzle6-adapter at version 2.0 and fails to resolve the dependencies.

As php-http/guzzle6-adapter 2.0 is not compatible with PHP 5.6 and 7.0, I changed the composer install command in Travis to force to require the 1.1 version