### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: php
 
 php:
     - 7.2
-
-sudo: false
+    - 7.3
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.14",
-    "phpunit/phpunit": "^5.7",
+    "phpunit/phpunit": "^8.0",
     "phpspec/phpspec": "^5.0",
     "symfony/yaml": "^4.2",
     "donatj/mock-webserver": "^2.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,4 +14,10 @@
     <testsuite>
         <directory>tests/</directory>
     </testsuite>
+
+     <filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/tests/Api/ApiTestCase.php
+++ b/tests/Api/ApiTestCase.php
@@ -8,13 +8,14 @@ use Akeneo\Pim\ApiClient\Api\AuthenticationApi;
 use donatj\MockWebServer\MockWebServer;
 use donatj\MockWebServer\Response;
 use donatj\MockWebServer\ResponseStack;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author    Laurent Petard <laurent.petard@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-abstract class ApiTestCase extends \PHPUnit_Framework_TestCase
+abstract class ApiTestCase extends TestCase
 {
     /** @var MockWebServer */
     protected $server;


### PR DESCRIPTION
# Changed log
- Upgrade the PHPUnit version to support the `php-7.2+` version.
- Add the `php-7.3` version because this version is stable.
- Using the PHPUnit namespace to support the latest PHP version.