### PR TITLE
Allow location header name to be lowercase

### DIFF
--- a/spec/Api/ProductMediaFileApiSpec.php
+++ b/spec/Api/ProductMediaFileApiSpec.php
@@ -129,9 +129,10 @@ class ProductMediaFileApiSpec extends ObjectBehavior
             ]
         ];
 
-        $response->getHeaders()->willReturn(['Location' => [
+        $response->hasHeader('Location')->willReturn(true);
+        $response->getHeader('Location')->willReturn([
             'http://localhost/api/rest/v1/media-files/1/e/e/d/1eed10f108bde68b279d6f903f17b4b053e9d89d_akeneo.png'
-        ]]);
+        ]);
 
         $resourceClient
             ->createMultipartResource(ProductMediaFileApi::MEDIA_FILES_URI, [], $requestParts)
@@ -164,9 +165,10 @@ class ProductMediaFileApiSpec extends ObjectBehavior
             ]
         ];
 
-        $response->getHeaders()->willReturn(['Location' => [
+        $response->hasHeader('Location')->willReturn(true);
+        $response->getHeader('Location')->willReturn([
             'http://localhost/api/rest/v1/media-files/1/e/e/d/1eed10f108bde68b279d6f903f17b4b053e9d89d_akeneo.png'
-        ]]);
+        ]);
 
         $resourceClient
             ->createMultipartResource(ProductMediaFileApi::MEDIA_FILES_URI, [], $requestParts)
@@ -202,9 +204,11 @@ class ProductMediaFileApiSpec extends ObjectBehavior
             ]
         ];
 
-        $response->getHeaders()->willReturn(['Location' => [
+        $response->hasHeader('Location')->willReturn(true);
+        $response->getHeader('Location')->willReturn(
+            [
             'http://localhost/api/rest/v1/media-files/1/e/e/d/1eed10f108bde68b279d6f903f17b4b053e9d89d_akeneo.png'
-        ]]);
+        ]);
 
         $resourceClient
             ->createMultipartResource(ProductMediaFileApi::MEDIA_FILES_URI, [], $requestParts)
@@ -236,7 +240,7 @@ class ProductMediaFileApiSpec extends ObjectBehavior
             ]
         ];
 
-        $response->getHeaders()->willReturn(['Location' => '']);
+        $response->hasHeader('Location')->willReturn(false);
 
         $resourceClient
             ->createMultipartResource(ProductMediaFileApi::MEDIA_FILES_URI, [], $requestParts)
@@ -268,7 +272,8 @@ class ProductMediaFileApiSpec extends ObjectBehavior
             ]
         ];
 
-        $response->getHeaders()->willReturn(['Location' => ['http://localhost/api/rest/v1/products/foo']]);
+        $response->hasHeader('Location')->willReturn(true);
+        $response->getHeader('Location')->willReturn(['http://localhost/api/rest/v1/products/foo']);
 
         $resourceClient
             ->createMultipartResource(ProductMediaFileApi::MEDIA_FILES_URI, [], $requestParts)

--- a/src/Api/ProductMediaFileApi.php
+++ b/src/Api/ProductMediaFileApi.php
@@ -130,11 +130,11 @@ class ProductMediaFileApi implements MediaFileApiInterface
      */
     protected function extractCodeFromCreationResponse(ResponseInterface $response)
     {
-        $locationHeaders = $response->getHeader('Location');
-
-        if (!isset($locationHeaders[0])) {
+        if (!$response->hasHeader('Location')) {
             throw new RuntimeException('The response does not contain the URI of the created media-file.');
         }
+
+		$locationHeaders = $response->getHeader('Location');
 
         $matches = [];
         if (1 !== preg_match(static::MEDIA_FILE_URI_CODE_REGEX, $locationHeaders[0], $matches)) {

--- a/src/Api/ProductMediaFileApi.php
+++ b/src/Api/ProductMediaFileApi.php
@@ -134,7 +134,7 @@ class ProductMediaFileApi implements MediaFileApiInterface
             throw new RuntimeException('The response does not contain the URI of the created media-file.');
         }
 
-		$locationHeaders = $response->getHeader('Location');
+        $locationHeaders = $response->getHeader('Location');
 
         $matches = [];
         if (1 !== preg_match(static::MEDIA_FILE_URI_CODE_REGEX, $locationHeaders[0], $matches)) {

--- a/src/Api/ProductMediaFileApi.php
+++ b/src/Api/ProductMediaFileApi.php
@@ -130,14 +130,14 @@ class ProductMediaFileApi implements MediaFileApiInterface
      */
     protected function extractCodeFromCreationResponse(ResponseInterface $response)
     {
-        $headers = $response->getHeaders();
+        $locationHeaders = $response->getHeader('Location');
 
-        if (!isset($headers['Location'][0])) {
+        if (!isset($locationHeaders[0])) {
             throw new RuntimeException('The response does not contain the URI of the created media-file.');
         }
 
         $matches = [];
-        if (1 !== preg_match(static::MEDIA_FILE_URI_CODE_REGEX, $headers['Location'][0], $matches)) {
+        if (1 !== preg_match(static::MEDIA_FILE_URI_CODE_REGEX, $locationHeaders[0], $matches)) {
             throw new RuntimeException('Unable to find the code in the URI of the created media-file.');
         }
 


### PR DESCRIPTION
Web servers and clients tend to cast header names to uppercase or lowercase. Guzzle handles these differences by [casting the names to lowercase](https://github.com/guzzle/psr7/blob/7858757f390bbe4b3d81762a97d6e6e786bb70ad/src/MessageTrait.php#L53-L64) when you try to access them. However, it will only do so when you get a single header, not when you request the entire collection.

This PR uses the `getHeader` function instead of `getHeaders`. As a result, it doesn't matter whether the server returns the header as `Location` or `location`.