### PR TITLE
Product media file api: bugfix: make header location check case insensitive

### DIFF
--- a/src/Api/ProductMediaFileApi.php
+++ b/src/Api/ProductMediaFileApi.php
@@ -132,12 +132,14 @@ class ProductMediaFileApi implements MediaFileApiInterface
     {
         $headers = $response->getHeaders();
 
-        if (!isset($headers['Location'][0])) {
+        $location = isset($headers['Location'][0]) ? $headers['Location'][0] : $headers['location'][0] ?? null;
+
+        if (is_null($location)) {
             throw new RuntimeException('The response does not contain the URI of the created media-file.');
         }
 
         $matches = [];
-        if (1 !== preg_match(static::MEDIA_FILE_URI_CODE_REGEX, $headers['Location'][0], $matches)) {
+        if (1 !== preg_match(static::MEDIA_FILE_URI_CODE_REGEX, $location, $matches)) {
             throw new RuntimeException('Unable to find the code in the URI of the created media-file.');
         }
 


### PR DESCRIPTION
In the project I'm working I was receiving the runtime exception `Akeneo\Pim\ApiClient\Exception\RuntimeException`with message `Unable to find the code in the URI of the created media-file.`.

After digging in the source I found that the key for the header `Location` was not returned with a capital L, instead it got `location`.

This PR fixes the issue and remains backwards compatible with the header in capitals.