### PR TITLE
API-1680 - Update compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@ A simple PHP client to use the [Akeneo PIM API](https://api.akeneo.com/).
 
 Matrix compatibility:
 
-| PIM version(s)  | API PHP Client version  | End of life    | CI status                                                                                                                    |
-|-----------------|-------------------------|----------------|------------------------------------------------------------------------------------------------------------------------------|
-| v2.0            | v1.0                    |  March 2019    | [![Build Status](https://travis-ci.org/akeneo/api-php-client.svg?branch=1.0)](https://travis-ci.org/akeneo/api-php-client)   |
-| v2.1 - v2.2     | v2.0                    |  March 2019    | [![Build Status](https://travis-ci.org/akeneo/api-php-client.svg?branch=2.0)](https://travis-ci.org/akeneo/api-php-client)   |
-| v2.3            | v3.0                    |  December 2019 | [![Build Status](https://travis-ci.org/akeneo/api-php-client.svg?branch=3.0)](https://travis-ci.org/akeneo/api-php-client)   |
-| v3.0            | v4.0                    |  August 2020   | [![Build Status](https://travis-ci.org/akeneo/api-php-client.svg?branch=4.0)](https://travis-ci.org/akeneo/api-php-client)   |
-| -               | master                  |  -             | [![CircleCI](https://circleci.com/gh/akeneo/api-php-client/tree/master.svg?style=svg)](https://circleci.com/gh/akeneo/api-php-client/tree/master)|
+| PIM version(s) | API PHP Client version | CI status                                                                                                                                         |
+|----------------|------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| v2.0           | v1.0                   | [![Build Status](https://travis-ci.org/akeneo/api-php-client.svg?branch=1.0)](https://travis-ci.org/akeneo/api-php-client)                        |
+| v2.1 - v2.2    | v2.0                   | [![Build Status](https://travis-ci.org/akeneo/api-php-client.svg?branch=2.0)](https://travis-ci.org/akeneo/api-php-client)                        |
+| v2.3           | v3.0                   | [![Build Status](https://travis-ci.org/akeneo/api-php-client.svg?branch=3.0)](https://travis-ci.org/akeneo/api-php-client)                        |
+| v3.0 - v4.0    | v4.0 - v5.0            | [![Build Status](https://travis-ci.org/akeneo/api-php-client.svg?branch=4.0)](https://travis-ci.org/akeneo/api-php-client)                        |
+| v5.0           | v6.0                   | -                                                                                                                                                 |
+| -              | master                 | [![CircleCI](https://circleci.com/gh/akeneo/api-php-client/tree/master.svg?style=svg)](https://circleci.com/gh/akeneo/api-php-client/tree/master) |
 
 Note that our PHP client is backward compatible.
 For example, if your PIM is currently a v2.3, you can still use a 1.0 version of the PHP client. The new endpoints available in v2.3 will not be available in the v1.0 of the PHP client.


### PR DESCRIPTION
I feel like old CI statuses aren't relevant but the column will be useful when next PIM version is released