### PR TITLE
Composer allow more versions of symfony/options-resolver and psr/http-message-implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,11 +24,11 @@
     "psr/http-message": "^1.0",
     "psr/http-client": "^1.0",
     "psr/http-factory": "^1.0",
-    "psr/http-message-implementation": "^1.0",
+    "psr/http-message-implementation": "^1.0|^2.0",
     "php-http/httplug": "^2.0",
     "php-http/discovery": "^1.6",
     "php-http/multipart-stream-builder": "^1.0",
-    "symfony/options-resolver": "^5.4|^6.0"
+    "symfony/options-resolver": "^5.4|^6.0|^7.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.5",


### PR DESCRIPTION
Allow symfony 7.0 version of symfony/options-resolver and 2.0 from psr/http-message-implementation in composer