### PR TITLE
chore: allow psr/http-message v1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   },
   "require": {
     "php": ">=8.2",
-    "psr/http-message": "^2.0",
+    "psr/http-message": "^1.0|^2.0",
     "psr/http-client": "^1.0",
     "psr/http-factory": "^1.0",
     "psr/http-message-implementation": "^1.0|^2.0",


### PR DESCRIPTION
This is required for installing the latest versions of this API Client on a Sylius project.

Sylius itself and many of its dependencies depend on `psr/http-message:1.0`